### PR TITLE
Updated git.host and git.api for Bitbucket Cloud

### DIFF
--- a/pages/hygieia/collectors/scm/bitbucket.md
+++ b/pages/hygieia/collectors/scm/bitbucket.md
@@ -87,8 +87,8 @@ The sample `application.properties` file lists parameters with sample values to 
 
 		# Mandatory parameters (comma separated, if multiple)
 		git.host=https://mybitbucketrepo.com,https://mybitbucketrepo2.com
-
-                #If using Bitbucket Cloud then go for below parameter for git.host
+		
+		#If using Bitbucket Cloud then go for below parameter for git.host
 		git.host=api.bitbucket.org/
 
 		git.username=user_for_git.host1,user_for_git.host2

--- a/pages/hygieia/collectors/scm/bitbucket.md
+++ b/pages/hygieia/collectors/scm/bitbucket.md
@@ -96,7 +96,8 @@ The sample `application.properties` file lists parameters with sample values to 
 		#convert password to base64
 		git.password=password_for_git.host1,password_for_git.host2
 		
-		#Since the older api version is now depreciated so current api is given below for Bitbucket Cloud.			#(REF:https://confluence.atlassian.com/bitbucket/rest-apis-222724129.html)
+		#Since the older api version is now depreciated so current api is given below for Bitbucket Cloud
+		#(REF:https://confluence.atlassian.com/bitbucket/rest-apis-222724129.html)
 		git.api=/api/2.0/repositories/
 		
 

--- a/pages/hygieia/collectors/scm/bitbucket.md
+++ b/pages/hygieia/collectors/scm/bitbucket.md
@@ -88,7 +88,7 @@ The sample `application.properties` file lists parameters with sample values to 
 		# Mandatory parameters (comma separated, if multiple)
 		git.host=https://mybitbucketrepo.com,https://mybitbucketrepo2.com
 
-                #If using Bitbucket Cloud then go for below parameter for git.host
+        #If using Bitbucket Cloud then go for below parameter for git.host
 		git.host=api.bitbucket.org/
 
 		git.username=user_for_git.host1,user_for_git.host2
@@ -96,7 +96,7 @@ The sample `application.properties` file lists parameters with sample values to 
 		#convert password to base64
 		git.password=password_for_git.host1,password_for_git.host2
 		
-		#Since the older api version is now depreciated so current api is given below for Bitbucket Cloud (REF:https://confluence.atla                ssia n.com/bitbucket/rest-apis-222724129.html)
+		#Since the older api version is now depreciated so current api is given below for Bitbucket Cloud (REF:https://confluence.atlassian.com/bitbucket/rest-apis-222724129.html).
 		git.api=/api/2.0/repositories/
 		
 

--- a/pages/hygieia/collectors/scm/bitbucket.md
+++ b/pages/hygieia/collectors/scm/bitbucket.md
@@ -87,12 +87,18 @@ The sample `application.properties` file lists parameters with sample values to 
 
 		# Mandatory parameters (comma separated, if multiple)
 		git.host=https://mybitbucketrepo.com,https://mybitbucketrepo2.com
+
+                #If using Bitbucket Cloud then go for below parameter for git.host
+		git.host=api.bitbucket.org/
+
 		git.username=user_for_git.host1,user_for_git.host2
 		
 		#convert password to base64
 		git.password=password_for_git.host1,password_for_git.host2
 		
-		git.api=/rest/api/1.0/
+		#Since the older api version is now depreciated so current api is given below for Bitbucket Cloud (REF:https://confluence.atla                ssia n.com/bitbucket/rest-apis-222724129.html)
+		git.api=/api/2.0/repositories/
+		
 
 		# Maximum number of days to go back in time when fetching commits
 		git.commitThresholdDays=15

--- a/pages/hygieia/collectors/scm/bitbucket.md
+++ b/pages/hygieia/collectors/scm/bitbucket.md
@@ -88,7 +88,7 @@ The sample `application.properties` file lists parameters with sample values to 
 		# Mandatory parameters (comma separated, if multiple)
 		git.host=https://mybitbucketrepo.com,https://mybitbucketrepo2.com
 
-        #If using Bitbucket Cloud then go for below parameter for git.host
+                #If using Bitbucket Cloud then go for below parameter for git.host
 		git.host=api.bitbucket.org/
 
 		git.username=user_for_git.host1,user_for_git.host2
@@ -96,7 +96,7 @@ The sample `application.properties` file lists parameters with sample values to 
 		#convert password to base64
 		git.password=password_for_git.host1,password_for_git.host2
 		
-		#Since the older api version is now depreciated so current api is given below for Bitbucket Cloud (REF:https://confluence.atlassian.com/bitbucket/rest-apis-222724129.html).
+		#Since the older api version is now depreciated so current api is given below for Bitbucket Cloud.			#(REF:https://confluence.atlassian.com/bitbucket/rest-apis-222724129.html)
 		git.api=/api/2.0/repositories/
 		
 


### PR DESCRIPTION
While configuring the Bitbucket collector I noticed that the git.api and git.host parameters in the application.properties(mentioned in the documentation) are not apt for the bitbucket cloud since "/rest/api/1.0/ " is depreciated as mentioned in **https://confluence.atlassian.com/bitbucket/rest-apis-222724129.html.**  
Since many people are still facing the issue of running the bitbucket collector for the cloud. I would like to create a pull request to update the same in the application.properties file in the documentation.

OLD:(as per current documentation)  
git.host=https://mybitbucketrepo.com  
git.api=/rest/api/1.0/ (this api is now deprecated and is not apt for bitbucket cloud)

NEW:(modified as per bitbucket cloud)  
git.host=api.bitbucket.org/  
git.api=/api/2.0/repositories/